### PR TITLE
Fixed type of argument to char in examples

### DIFF
--- a/Text/Parsec/Token.hs
+++ b/Text/Parsec/Token.hs
@@ -64,12 +64,12 @@ data GenLanguageDef s u m
     nestedComments :: Bool,
 
     -- | This parser should accept any start characters of identifiers. For
-    -- example @letter \<|> char \"_\"@. 
+    -- example @letter \<|> char \'_\'@. 
 
     identStart     :: ParsecT s u m Char,
 
     -- | This parser should accept any legal tail characters of identifiers.
-    -- For example @alphaNum \<|> char \"_\"@. 
+    -- For example @alphaNum \<|> char \'_\'@. 
 
     identLetter    :: ParsecT s u m Char,
 


### PR DESCRIPTION
The examples for identStart and identLetter were calling `char "_"`. char should take a character literal, not a string.