### PR TITLE
Test for #35 added + some cosmetic changes

### DIFF
--- a/Text/Parsec/Language.hs
+++ b/Text/Parsec/Language.hs
@@ -3,14 +3,14 @@
 -- Module      :  Text.Parsec.Language
 -- Copyright   :  (c) Daan Leijen 1999-2001, (c) Paolo Martini 2007
 -- License     :  BSD-style (see the LICENSE file)
--- 
+--
 -- Maintainer  :  derek.a.elkins@gmail.com
 -- Stability   :  provisional
 -- Portability :  non-portable (uses non-portable module Text.Parsec.Token)
 --
 -- A helper module that defines some language definitions that can be used
 -- to instantiate a token parser (see "Text.Parsec.Token").
--- 
+--
 -----------------------------------------------------------------------------
 
 module Text.Parsec.Language
@@ -41,9 +41,9 @@ haskellStyle = emptyDef
                 , commentLine    = "--"
                 , nestedComments = True
                 , identStart     = letter
-                , identLetter	 = alphaNum <|> oneOf "_'"
-                , opStart	 = opLetter haskellStyle
-                , opLetter	 = oneOf ":!#$%&*+./<=>?@\\^|-~"
+                , identLetter    = alphaNum <|> oneOf "_'"
+                , opStart        = opLetter haskellStyle
+                , opLetter       = oneOf ":!#$%&*+./<=>?@\\^|-~"
                 , reservedOpNames= []
                 , reservedNames  = []
                 , caseSensitive  = True
@@ -55,16 +55,17 @@ haskellStyle = emptyDef
 
 javaStyle  :: LanguageDef st
 javaStyle   = emptyDef
-		{ commentStart	 = "/*"
-		, commentEnd	 = "*/"
-		, commentLine	 = "//"
-		, nestedComments = True
-		, identStart	 = letter
-		, identLetter	 = alphaNum <|> oneOf "_'"
-		, reservedNames  = []
-		, reservedOpNames= []
+                { commentStart   = "/*"
+                , commentEnd     = "*/"
+                , commentLine    = "//"
+                , nestedComments = True
+                , identStart     = letter
+                , identLetter    = alphaNum <|> oneOf "_'"
+                , reservedNames  = []
+                , reservedOpNames= []
                 , caseSensitive  = False
-		}
+                }
+
 
 -----------------------------------------------------------
 -- minimal language definition
@@ -91,7 +92,6 @@ emptyDef    = LanguageDef
                }
 
 
-
 -----------------------------------------------------------
 -- Haskell
 -----------------------------------------------------------
@@ -105,12 +105,12 @@ haskell      = makeTokenParser haskellDef
 
 haskellDef  :: LanguageDef st
 haskellDef   = haskell98Def
-	        { identLetter	 = identLetter haskell98Def <|> char '#'
-	        , reservedNames	 = reservedNames haskell98Def ++
-    				   ["foreign","import","export","primitive"
-    				   ,"_ccall_","_casm_"
-    				   ,"forall"
-    				   ]
+                { identLetter    = identLetter haskell98Def <|> char '#'
+                , reservedNames  = reservedNames haskell98Def ++
+                                   ["foreign","import","export","primitive"
+                                   ,"_ccall_","_casm_"
+                                   ,"forall"
+                                   ]
                 }
 
 -- | The language definition for the language Haskell98.
@@ -142,8 +142,8 @@ mondrian    = makeTokenParser mondrianDef
 
 mondrianDef :: LanguageDef st
 mondrianDef = javaStyle
-		{ reservedNames = [ "case", "class", "default", "extends"
-				  , "import", "in", "let", "new", "of", "package"
-				  ]
+                { reservedNames = [ "case", "class", "default", "extends"
+                                  , "import", "in", "let", "new", "of", "package"
+                                  ]
                 , caseSensitive  = True
-		}
+                }

--- a/Text/Parsec/Token.hs
+++ b/Text/Parsec/Token.hs
@@ -3,14 +3,14 @@
 -- Module      :  Text.Parsec.Token
 -- Copyright   :  (c) Daan Leijen 1999-2001, (c) Paolo Martini 2007
 -- License     :  BSD-style (see the LICENSE file)
--- 
+--
 -- Maintainer  :  derek.a.elkins@gmail.com
 -- Stability   :  provisional
 -- Portability :  non-portable (uses local universal quantification: PolymorphicComponents)
--- 
+--
 -- A helper module to parse lexical elements (tokens). See 'makeTokenParser'
 -- for a description of how to use it.
--- 
+--
 -----------------------------------------------------------------------------
 
 {-# LANGUAGE PolymorphicComponents #-}
@@ -42,58 +42,58 @@ type LanguageDef st = GenLanguageDef String st Identity
 -- contains some default definitions.
 
 data GenLanguageDef s u m
-    = LanguageDef { 
-    
+    = LanguageDef {
+
     -- | Describes the start of a block comment. Use the empty string if the
-    -- language doesn't support block comments. For example \"\/*\". 
+    -- language doesn't support block comments. For example \"\/*\".
 
     commentStart   :: String,
 
     -- | Describes the end of a block comment. Use the empty string if the
-    -- language doesn't support block comments. For example \"*\/\". 
+    -- language doesn't support block comments. For example \"*\/\".
 
     commentEnd     :: String,
 
     -- | Describes the start of a line comment. Use the empty string if the
-    -- language doesn't support line comments. For example \"\/\/\". 
+    -- language doesn't support line comments. For example \"\/\/\".
 
     commentLine    :: String,
 
-    -- | Set to 'True' if the language supports nested block comments. 
+    -- | Set to 'True' if the language supports nested block comments.
 
     nestedComments :: Bool,
 
     -- | This parser should accept any start characters of identifiers. For
-    -- example @letter \<|> char \'_\'@. 
+    -- example @letter \<|> char \'_\'@.
 
     identStart     :: ParsecT s u m Char,
 
     -- | This parser should accept any legal tail characters of identifiers.
-    -- For example @alphaNum \<|> char \'_\'@. 
+    -- For example @alphaNum \<|> char \'_\'@.
 
     identLetter    :: ParsecT s u m Char,
 
     -- | This parser should accept any start characters of operators. For
-    -- example @oneOf \":!#$%&*+.\/\<=>?\@\\\\^|-~\"@ 
+    -- example @oneOf \":!#$%&*+.\/\<=>?\@\\\\^|-~\"@
 
     opStart        :: ParsecT s u m Char,
 
     -- | This parser should accept any legal tail characters of operators.
     -- Note that this parser should even be defined if the language doesn't
     -- support user-defined operators, or otherwise the 'reservedOp'
-    -- parser won't work correctly. 
+    -- parser won't work correctly.
 
     opLetter       :: ParsecT s u m Char,
 
-    -- | The list of reserved identifiers. 
+    -- | The list of reserved identifiers.
 
     reservedNames  :: [String],
 
-    -- | The list of reserved operators. 
+    -- | The list of reserved operators.
 
     reservedOpNames:: [String],
 
-    -- | Set to 'True' if the language is case sensitive. 
+    -- | Set to 'True' if the language is case sensitive.
 
     caseSensitive  :: Bool
 
@@ -119,11 +119,11 @@ data GenTokenParser s u m
         -- a single token using 'try'.
 
         identifier       :: ParsecT s u m String,
-        
-        -- | The lexeme parser @reserved name@ parses @symbol 
+
+        -- | The lexeme parser @reserved name@ parses @symbol
         -- name@, but it also checks that the @name@ is not a prefix of a
         -- valid identifier. A @reserved@ word is treated as a single token
-        -- using 'try'. 
+        -- using 'try'.
 
         reserved         :: String -> ParsecT s u m (),
 
@@ -132,23 +132,22 @@ data GenTokenParser s u m
         -- operators. Legal operator (start) characters and reserved operators
         -- are defined in the 'LanguageDef' that is passed to
         -- 'makeTokenParser'. An @operator@ is treated as a
-        -- single token using 'try'. 
+        -- single token using 'try'.
 
         operator         :: ParsecT s u m String,
 
         -- |The lexeme parser @reservedOp name@ parses @symbol
         -- name@, but it also checks that the @name@ is not a prefix of a
         -- valid operator. A @reservedOp@ is treated as a single token using
-        -- 'try'. 
+        -- 'try'.
 
         reservedOp       :: String -> ParsecT s u m (),
-
 
         -- | This lexeme parser parses a single literal character. Returns the
         -- literal character value. This parsers deals correctly with escape
         -- sequences. The literal character is parsed according to the grammar
         -- rules defined in the Haskell report (which matches most programming
-        -- languages quite closely). 
+        -- languages quite closely).
 
         charLiteral      :: ParsecT s u m Char,
 
@@ -156,7 +155,7 @@ data GenTokenParser s u m
         -- string value. This parsers deals correctly with escape sequences and
         -- gaps. The literal string is parsed according to the grammar rules
         -- defined in the Haskell report (which matches most programming
-        -- languages quite closely). 
+        -- languages quite closely).
 
         stringLiteral    :: ParsecT s u m String,
 
@@ -164,7 +163,7 @@ data GenTokenParser s u m
         -- number). Returns the value of the number. The number can be
         -- specified in 'decimal', 'hexadecimal' or
         -- 'octal'. The number is parsed according to the grammar
-        -- rules in the Haskell report. 
+        -- rules in the Haskell report.
 
         natural          :: ParsecT s u m Integer,
 
@@ -173,42 +172,42 @@ data GenTokenParser s u m
         -- sign (i.e. \'-\' or \'+\'). Returns the value of the number. The
         -- number can be specified in 'decimal', 'hexadecimal'
         -- or 'octal'. The number is parsed according
-        -- to the grammar rules in the Haskell report. 
-        
+        -- to the grammar rules in the Haskell report.
+
         integer          :: ParsecT s u m Integer,
 
         -- | This lexeme parser parses a floating point value. Returns the value
         -- of the number. The number is parsed according to the grammar rules
-        -- defined in the Haskell report. 
+        -- defined in the Haskell report.
 
         float            :: ParsecT s u m Double,
 
         -- | This lexeme parser parses either 'natural' or a 'float'.
         -- Returns the value of the number. This parsers deals with
         -- any overlap in the grammar rules for naturals and floats. The number
-        -- is parsed according to the grammar rules defined in the Haskell report. 
+        -- is parsed according to the grammar rules defined in the Haskell report.
 
         naturalOrFloat   :: ParsecT s u m (Either Integer Double),
 
         -- | Parses a positive whole number in the decimal system. Returns the
-        -- value of the number. 
+        -- value of the number.
 
         decimal          :: ParsecT s u m Integer,
 
         -- | Parses a positive whole number in the hexadecimal system. The number
         -- should be prefixed with \"0x\" or \"0X\". Returns the value of the
-        -- number. 
+        -- number.
 
         hexadecimal      :: ParsecT s u m Integer,
 
         -- | Parses a positive whole number in the octal system. The number
         -- should be prefixed with \"0o\" or \"0O\". Returns the value of the
-        -- number. 
+        -- number.
 
         octal            :: ParsecT s u m Integer,
 
         -- | Lexeme parser @symbol s@ parses 'string' @s@ and skips
-        -- trailing white space. 
+        -- trailing white space.
 
         symbol           :: String -> ParsecT s u m String,
 
@@ -217,7 +216,7 @@ data GenTokenParser s u m
         -- token (lexeme) is defined using @lexeme@, this way every parse
         -- starts at a point without white space. Parsers that use @lexeme@ are
         -- called /lexeme/ parsers in this document.
-        -- 
+        --
         -- The only point where the 'whiteSpace' parser should be
         -- called explicitly is the start of the main parser in order to skip
         -- any leading white space.
@@ -234,7 +233,7 @@ data GenTokenParser s u m
         -- occurrences of a 'space', a line comment or a block (multi
         -- line) comment. Block comments may be nested. How comments are
         -- started and ended is defined in the 'LanguageDef'
-        -- that is passed to 'makeTokenParser'. 
+        -- that is passed to 'makeTokenParser'.
 
         whiteSpace       :: ParsecT s u m (),
 
@@ -244,17 +243,17 @@ data GenTokenParser s u m
         parens           :: forall a. ParsecT s u m a -> ParsecT s u m a,
 
         -- | Lexeme parser @braces p@ parses @p@ enclosed in braces (\'{\' and
-        -- \'}\'), returning the value of @p@. 
+        -- \'}\'), returning the value of @p@.
 
         braces           :: forall a. ParsecT s u m a -> ParsecT s u m a,
 
         -- | Lexeme parser @angles p@ parses @p@ enclosed in angle brackets (\'\<\'
-        -- and \'>\'), returning the value of @p@. 
+        -- and \'>\'), returning the value of @p@.
 
         angles           :: forall a. ParsecT s u m a -> ParsecT s u m a,
 
         -- | Lexeme parser @brackets p@ parses @p@ enclosed in brackets (\'[\'
-        -- and \']\'), returning the value of @p@. 
+        -- and \']\'), returning the value of @p@.
 
         brackets         :: forall a. ParsecT s u m a -> ParsecT s u m a,
 
@@ -263,22 +262,22 @@ data GenTokenParser s u m
         squares          :: forall a. ParsecT s u m a -> ParsecT s u m a,
 
         -- | Lexeme parser |semi| parses the character \';\' and skips any
-        -- trailing white space. Returns the string \";\". 
+        -- trailing white space. Returns the string \";\".
 
         semi             :: ParsecT s u m String,
 
         -- | Lexeme parser @comma@ parses the character \',\' and skips any
-        -- trailing white space. Returns the string \",\". 
+        -- trailing white space. Returns the string \",\".
 
         comma            :: ParsecT s u m String,
 
         -- | Lexeme parser @colon@ parses the character \':\' and skips any
-        -- trailing white space. Returns the string \":\". 
+        -- trailing white space. Returns the string \":\".
 
         colon            :: ParsecT s u m String,
 
         -- | Lexeme parser @dot@ parses the character \'.\' and skips any
-        -- trailing white space. Returns the string \".\". 
+        -- trailing white space. Returns the string \".\".
 
         dot              :: ParsecT s u m String,
 
@@ -289,19 +288,19 @@ data GenTokenParser s u m
         semiSep          :: forall a . ParsecT s u m a -> ParsecT s u m [a],
 
         -- | Lexeme parser @semiSep1 p@ parses /one/ or more occurrences of @p@
-        -- separated by 'semi'. Returns a list of values returned by @p@. 
+        -- separated by 'semi'. Returns a list of values returned by @p@.
 
         semiSep1         :: forall a . ParsecT s u m a -> ParsecT s u m [a],
 
         -- | Lexeme parser @commaSep p@ parses /zero/ or more occurrences of
         -- @p@ separated by 'comma'. Returns a list of values returned
-        -- by @p@. 
+        -- by @p@.
 
         commaSep         :: forall a . ParsecT s u m a -> ParsecT s u m [a],
 
         -- | Lexeme parser @commaSep1 p@ parses /one/ or more occurrences of
         -- @p@ separated by 'comma'. Returns a list of values returned
-        -- by @p@. 
+        -- by @p@.
 
         commaSep1        :: forall a . ParsecT s u m a -> ParsecT s u m [a]
     }
@@ -330,11 +329,11 @@ data GenTokenParser s u m
 -- >  expr  =   parens expr
 -- >        <|> identifier
 -- >        <|> ...
--- >       
+-- >
 -- >
 -- >  -- The lexer
--- >  lexer       = P.makeTokenParser haskellDef    
--- >      
+-- >  lexer       = P.makeTokenParser haskellDef
+-- >
 -- >  parens      = P.parens lexer
 -- >  braces      = P.braces lexer
 -- >  identifier  = P.identifier lexer
@@ -344,48 +343,48 @@ data GenTokenParser s u m
 makeTokenParser :: (Stream s m Char)
                 => GenLanguageDef s u m -> GenTokenParser s u m
 makeTokenParser languageDef
-    = TokenParser{ identifier = identifier
-                 , reserved = reserved
-                 , operator = operator
-                 , reservedOp = reservedOp
+    = TokenParser { identifier = identifier
+                  , reserved = reserved
+                  , operator = operator
+                  , reservedOp = reservedOp
 
-                 , charLiteral = charLiteral
-                 , stringLiteral = stringLiteral
-                 , natural = natural
-                 , integer = integer
-                 , float = float
-                 , naturalOrFloat = naturalOrFloat
-                 , decimal = decimal
-                 , hexadecimal = hexadecimal
-                 , octal = octal
+                  , charLiteral = charLiteral
+                  , stringLiteral = stringLiteral
+                  , natural = natural
+                  , integer = integer
+                  , float = float
+                  , naturalOrFloat = naturalOrFloat
+                  , decimal = decimal
+                  , hexadecimal = hexadecimal
+                  , octal = octal
 
-                 , symbol = symbol
-                 , lexeme = lexeme
-                 , whiteSpace = whiteSpace
+                  , symbol = symbol
+                  , lexeme = lexeme
+                  , whiteSpace = whiteSpace
 
-                 , parens = parens
-                 , braces = braces
-                 , angles = angles
-                 , brackets = brackets
-                 , squares = brackets
-                 , semi = semi
-                 , comma = comma
-                 , colon = colon
-                 , dot = dot
-                 , semiSep = semiSep
-                 , semiSep1 = semiSep1
-                 , commaSep = commaSep
-                 , commaSep1 = commaSep1
-                 }
+                  , parens = parens
+                  , braces = braces
+                  , angles = angles
+                  , brackets = brackets
+                  , squares = brackets
+                  , semi = semi
+                  , comma = comma
+                  , colon = colon
+                  , dot = dot
+                  , semiSep = semiSep
+                  , semiSep1 = semiSep1
+                  , commaSep = commaSep
+                  , commaSep1 = commaSep1
+                  }
     where
 
     -----------------------------------------------------------
     -- Bracketing
     -----------------------------------------------------------
-    parens p        = between (symbol "(") (symbol ")") p
-    braces p        = between (symbol "{") (symbol "}") p
-    angles p        = between (symbol "<") (symbol ">") p
-    brackets p      = between (symbol "[") (symbol "]") p
+    parens          = between (symbol "(") (symbol ")")
+    braces          = between (symbol "{") (symbol "}")
+    angles          = between (symbol "<") (symbol ">")
+    brackets        = between (symbol "[") (symbol "]")
 
     semi            = symbol ";"
     comma           = symbol ","
@@ -467,7 +466,7 @@ makeTokenParser languageDef
 
 
     -- escape code tables
-    escMap          = zip ("abfnrtv\\\"\'") ("\a\b\f\n\r\t\v\\\"\'")
+    escMap          = zip "abfnrtv\\\"\'" "\a\b\f\n\r\t\v\\\"\'"
     asciiMap        = zip (ascii3codes ++ ascii2codes) (ascii3 ++ ascii2)
 
     ascii2codes     = ["BS","HT","LF","VT","FF","CR","SO","SI","EM",
@@ -486,11 +485,11 @@ makeTokenParser languageDef
     -----------------------------------------------------------
     -- Numbers
     -----------------------------------------------------------
-    naturalOrFloat  = lexeme (natFloat) <?> "number"
+    naturalOrFloat  = lexeme natFloat <?> "number"
 
-    float           = lexeme floating   <?> "float"
-    integer         = lexeme int        <?> "integer"
-    natural         = lexeme nat        <?> "natural"
+    float           = lexeme floating <?> "float"
+    integer         = lexeme int      <?> "integer"
+    natural         = lexeme nat      <?> "natural"
 
 
     -- floats
@@ -587,20 +586,20 @@ makeTokenParser languageDef
     operator =
         lexeme $ try $
         do{ name <- oper
-          ; if (isReservedOp name)
+          ; if isReservedOp name
              then unexpected ("reserved operator " ++ show name)
              else return name
           }
 
     oper =
-        do{ c <- (opStart languageDef)
+        do{ c <- opStart languageDef
           ; cs <- many (opLetter languageDef)
           ; return (c:cs)
           }
         <?> "operator"
 
-    isReservedOp name =
-        isReserved (sort (reservedOpNames languageDef)) name
+    isReservedOp =
+        isReserved (sort (reservedOpNames languageDef))
 
 
     -----------------------------------------------------------
@@ -628,7 +627,7 @@ makeTokenParser languageDef
     identifier =
         lexeme $ try $
         do{ name <- ident
-          ; if (isReservedName name)
+          ; if isReservedName name
              then unexpected ("reserved word " ++ show name)
              else return name
           }
@@ -652,7 +651,7 @@ makeTokenParser languageDef
         = scan names
         where
           scan []       = False
-          scan (r:rs)   = case (compare r name) of
+          scan (r:rs)   = case compare r name of
                             LT  -> scan rs
                             EQ  -> True
                             GT  -> False

--- a/test/Bugs.hs
+++ b/test/Bugs.hs
@@ -8,9 +8,11 @@ import Test.Framework
 import qualified Bugs.Bug2
 import qualified Bugs.Bug6
 import qualified Bugs.Bug9
+-- import qualified Bugs.Bug35
 
 bugs :: [Test]
 bugs = [ Bugs.Bug2.main
        , Bugs.Bug6.main
        , Bugs.Bug9.main
+       -- , Bugs.Bug35.main
        ]

--- a/test/Bugs/Bug35.hs
+++ b/test/Bugs/Bug35.hs
@@ -1,0 +1,40 @@
+
+module Bugs.Bug35 (main) where
+
+import Text.Parsec
+import Text.Parsec.Language
+import Text.Parsec.String
+import qualified Text.Parsec.Token as Token
+
+import Test.HUnit hiding (Test)
+import Test.Framework
+import Test.Framework.Providers.HUnit
+
+trickyFloats :: [String]
+trickyFloats =
+    [ "1.5339794352098402e-118"
+    , "2.108934760892056e-59"
+    , "2.250634744599241e-19"
+    , "5.0e-324"
+    , "5.960464477539063e-8"
+    , "0.25996181067141905"
+    , "0.3572019862807257"
+    , "0.46817723004874223"
+    , "0.9640035681058178"
+    , "4.23808622486133"
+    , "4.540362294799751"
+    , "5.212384849884261"
+    , "13.958257048123212"
+    , "32.96176575630599"
+    , "38.47735512322269"
+    ]
+
+float :: Parser Double
+float = Token.float (Token.makeTokenParser emptyDef)
+
+testBatch :: Assertion
+testBatch = mapM_ testFloat trickyFloats
+    where testFloat x = parse float "" x @?= Right (read x :: Double)
+
+main :: Test
+main = testCase "Quality of output of Text.Parsec.Token.float (#35)" testBatch


### PR DESCRIPTION
Here is test for bug #35, I used QuickCheck to find out floating point values that are parsed by `read` OK, but not that precisely by `Text.Parsec.Token.float`. Here are also some minor changes:

* file `Language.hs` is untabified, because it's better to avoid tabs in Haskell source (GHC warnings say);
* some cosmetic changes in `Text.Parsec.Token`, they were reported by flycheck while I was reading the source, in some cases I saw that it's better to leave something "as is", but most of the warning were perfectly legal. Also, there are quite a lot of trailing whitespace in this module and I guess across entire source code, it's better to purge it, my Emacs is programmed to delete trailing whitespace on saving, so elimination of the whitespace is rather side-effect of my editing, not conscious effort.