### PR TITLE
Text.Parsec.Language.LanguageDef - Add spaceChar

### DIFF
--- a/Text/Parsec/Language.hs
+++ b/Text/Parsec/Language.hs
@@ -25,6 +25,7 @@ module Text.Parsec.Language
 
 import Text.Parsec
 import Text.Parsec.Token
+import Data.Char (isSpace)
 
 -----------------------------------------------------------
 -- Styles: haskellStyle, javaStyle
@@ -88,6 +89,7 @@ emptyDef    = LanguageDef
                , reservedOpNames= []
                , reservedNames  = []
                , caseSensitive  = True
+               , spaceChar      = satisfy isSpace
                }
 
 

--- a/Text/Parsec/Token.hs
+++ b/Text/Parsec/Token.hs
@@ -24,7 +24,7 @@ module Text.Parsec.Token
     , makeTokenParser
     ) where
 
-import Data.Char ( isAlpha, toLower, toUpper, isSpace, digitToInt )
+import Data.Char ( isAlpha, toLower, toUpper, digitToInt )
 import Data.List ( nub, sort )
 import Control.Monad.Identity
 import Text.Parsec.Prim
@@ -95,8 +95,11 @@ data GenLanguageDef s u m
 
     -- | Set to 'True' if the language is case sensitive. 
 
-    caseSensitive  :: Bool
+    caseSensitive  :: Bool,
 
+    -- | Is whitespace character?
+
+    spaceChar     :: ParsecT s u m Char
     }
 
 -----------------------------------------------------------
@@ -687,7 +690,7 @@ makeTokenParser languageDef
 
 
     simpleSpace =
-        skipMany1 (satisfy isSpace)
+        skipMany1 (spaceChar languageDef)
 
     oneLineComment =
         do{ try (string (commentLine languageDef))


### PR DESCRIPTION
Adds spaceChar field to the LanguageDef record. This helps if one builds whitespace sensitive parsers using Text.Parsec.Token. This should resolve #24