### PR TITLE
Option to change whitespace in token parsing.

### DIFF
--- a/Text/Parsec/Token.hs
+++ b/Text/Parsec/Token.hs
@@ -22,6 +22,7 @@ module Text.Parsec.Token
     , TokenParser
     , GenTokenParser (..)
     , makeTokenParser
+    , makeTokenParser'
     ) where
 
 import Data.Char ( isAlpha, toLower, toUpper, isSpace, digitToInt )
@@ -343,7 +344,17 @@ data GenTokenParser s u m
 
 makeTokenParser :: (Stream s m Char)
                 => GenLanguageDef s u m -> GenTokenParser s u m
-makeTokenParser languageDef
+makeTokenParser = makeTokenParser' isSpace
+
+
+-- | Same as @makeTokenParser@, but a function which determines whether or
+-- not a character should count as whitespace is provided. This is
+-- useful for parsing languages like Python, which depend upon
+-- indentation and newlines for syntax.
+
+makeTokenParser' :: (Stream s m Char)
+                => (Char -> Bool) -> GenLanguageDef s u m -> GenTokenParser s u m
+makeTokenParser' isSpace languageDef
     = TokenParser{ identifier = identifier
                  , reserved = reserved
                  , operator = operator


### PR DESCRIPTION
Currently there is no way to alter what the token parser considers to be whitespace. This is an issue if one wishes to parse certain indentation specific languages, for instance with the following package:

https://hackage.haskell.org/package/indents

If newlines are consumed by the lexeme parsers in Text.Parsec.Tokens then it is difficult to work with certain languages which depend upon indentation and newlines, such as Python 3.

https://docs.python.org/3/reference/grammar.html

As an example if statements in Python either require semi-colon separated statements after the conditional, e.g.:

if blah: stmt1; stmt2

Or the statements must occur on a newline, but must also be indented further. Not both. This makes it difficult to use Text.Parsec.Tokens.makeTokenParser in its current form, as it ignores any form of newline since it uses Data.Char.isSpace by default to decided upon whitespace.