### PR TITLE
add sepBy' and sepBy1' combinators

### DIFF
--- a/Text/Parsec/Combinator.hs
+++ b/Text/Parsec/Combinator.hs
@@ -20,6 +20,7 @@ module Text.Parsec.Combinator
     , skipMany1
     , many1
     , sepBy, sepBy1
+    , sepBy', sepBy1'
     , endBy, endBy1
     , sepEndBy, sepEndBy1
     , chainl, chainl1
@@ -117,6 +118,20 @@ sepBy1 :: (Stream s m t) => ParsecT s u m a -> ParsecT s u m sep -> ParsecT s u 
 sepBy1 p sep        = do{ x <- p
                         ; xs <- many (sep >> p)
                         ; return (x:xs)
+                        }
+
+sepBy' :: (Stream s m t) => ParsecT s u m a -> ParsecT s u m sep -> ParsecT s u m [a]
+sepBy' p sep        = sepBy1' p sep <|> return []
+
+sepBy1' :: (Stream s m t) => ParsecT s u m a -> ParsecT s u m sep -> ParsecT s u m [a]
+sepBy1' p sep       = do{ x <- p
+                        ; xs <- piter []
+                        ; return $ x:reverse xs
+                        }
+    where piter acc = do{ m <- optionMaybe sep
+                        ; case m of
+                            Nothing -> return acc
+                            Just _  -> do{ x' <- p; piter $ x':acc }
                         }
 
 


### PR DESCRIPTION
this PR is majorly to introduce two combinators that have similar but slightly different behavior than original `sepBy` and `sepBy1`.

here is the illustration:

```haskell
import Text.ParserCombinators.Parsec as Par
let cva1 = (char 'a' `sepBy` (spaces *> char ',' *> spaces)) :: Parser [Char]
let cva2 = (char 'a' `sepBy'` (spaces *> char ',' *> spaces)) :: Parser [Char] -- watch out, it's sepBy'
parse cva1 "" "a, a, a" -- fine
parse cva2 "" "a, a, a" -- fine
parse cva1 "" "a, a, a " -- not fine
parse cva2 "" "a, a, a " -- fine
```

here we defined `cva`s to be "comma separated letter 'a's". for `cva1`, it will accept such list of `a`s without any trailing spaces, but if any trailing spaces exist, it will reject, while the one that uses `sepBy'` combinator accepts both cases.

the reason why `sepBy` doesn't accept the second case is, `sep == spaces *> char ',' *> spaces`, where `sep` has actually started to accept `spaces` already when it comes to the trailing spaces, and therefore it will expect more spaces, or comma, but not eof, so it rejects the input. 

also another variation `sepEndBy` doesn't work because it requires the input terminates by the exact `sep` parser. 

i've been looking around and couldn't find any existing solution to this incident so i ended up deciding to write one.