### PR TITLE
Fix float parsing

### DIFF
--- a/Text/Parsec/Token.hs
+++ b/Text/Parsec/Token.hs
@@ -530,31 +530,31 @@ makeTokenParser languageDef
                         }
 
     fractExponent n = do{ fract <- fraction
-                        ; expo  <- option 1.0 exponent'
-                        ; return ((fromInteger n + fract)*expo)
+                        ; expo  <- option "" exponent'
+                        ; readDouble (show n ++ fract ++ expo)
                         }
                     <|>
                       do{ expo <- exponent'
-                        ; return ((fromInteger n)*expo)
+                        ; readDouble (show n ++ expo)
                         }
+                      where
+                        readDouble s =
+                          case reads s of
+                            [(x, "")] -> return x
+                            _         -> parserZero
 
     fraction        = do{ char '.'
                         ; digits <- many1 digit <?> "fraction"
-                        ; return (foldr op 0.0 digits)
+                        ; return ('.' : digits)
                         }
                       <?> "fraction"
-                    where
-                      op d f    = (f + fromIntegral (digitToInt d))/10.0
 
     exponent'       = do{ oneOf "eE"
-                        ; f <- sign
+                        ; sign' <- fmap (:[]) (oneOf "+-") <|> return ""
                         ; e <- decimal <?> "exponent"
-                        ; return (power (f e))
+                        ; return ('e' : sign' ++ show e)
                         }
                       <?> "exponent"
-                    where
-                       power e  | e < 0      = 1.0/power(-e)
-                                | otherwise  = fromInteger (10^e)
 
 
     -- integers and naturals

--- a/test/Bugs.hs
+++ b/test/Bugs.hs
@@ -8,9 +8,11 @@ import Test.Framework
 import qualified Bugs.Bug2
 import qualified Bugs.Bug6
 import qualified Bugs.Bug9
+-- import qualified Bugs.Bug35
 
 bugs :: [Test]
 bugs = [ Bugs.Bug2.main
        , Bugs.Bug6.main
        , Bugs.Bug9.main
+       -- , Bugs.Bug35.main
        ]

--- a/test/Bugs.hs
+++ b/test/Bugs.hs
@@ -8,11 +8,11 @@ import Test.Framework
 import qualified Bugs.Bug2
 import qualified Bugs.Bug6
 import qualified Bugs.Bug9
--- import qualified Bugs.Bug35
+import qualified Bugs.Bug35
 
 bugs :: [Test]
 bugs = [ Bugs.Bug2.main
        , Bugs.Bug6.main
        , Bugs.Bug9.main
-       -- , Bugs.Bug35.main
+       , Bugs.Bug35.main
        ]

--- a/test/Bugs/Bug35.hs
+++ b/test/Bugs/Bug35.hs
@@ -1,0 +1,40 @@
+
+module Bugs.Bug35 (main) where
+
+import Text.Parsec
+import Text.Parsec.Language
+import Text.Parsec.String
+import qualified Text.Parsec.Token as Token
+
+import Test.HUnit hiding (Test)
+import Test.Framework
+import Test.Framework.Providers.HUnit
+
+trickyFloats :: [String]
+trickyFloats =
+    [ "1.5339794352098402e-118"
+    , "2.108934760892056e-59"
+    , "2.250634744599241e-19"
+    , "5.0e-324"
+    , "5.960464477539063e-8"
+    , "0.25996181067141905"
+    , "0.3572019862807257"
+    , "0.46817723004874223"
+    , "0.9640035681058178"
+    , "4.23808622486133"
+    , "4.540362294799751"
+    , "5.212384849884261"
+    , "13.958257048123212"
+    , "32.96176575630599"
+    , "38.47735512322269"
+    ]
+
+float :: Parser Double
+float = Token.float (Token.makeTokenParser emptyDef)
+
+testBatch :: Assertion
+testBatch = mapM_ testFloat trickyFloats
+    where testFloat x = parse float "" x @?= Right (read x :: Double)
+
+main :: Test
+main = testCase "Quality of output of Text.Parsec.Token.float (#35)" testBatch


### PR DESCRIPTION
Fixes #35, by avoiding floating point operations such as addition and multiplication, and using the `Read Double` instance instead.

I used @mrkkrp's tests from his old pull request and enabled them, they now pass.