### PR TITLE
[doc] upper & lower functions refer to unicode

### DIFF
--- a/Text/Parsec/Char.hs
+++ b/Text/Parsec/Char.hs
@@ -75,13 +75,13 @@ endOfLine           = newline <|> crlf       <?> "new-line"
 tab :: (Stream s m Char) => ParsecT s u m Char
 tab                 = char '\t'             <?> "tab"
 
--- | Parses an upper case letter (a character between \'A\' and \'Z\').
+-- | Parses an upper case unicode character
 -- Returns the parsed character.
 
 upper :: (Stream s m Char) => ParsecT s u m Char
 upper               = satisfy isUpper       <?> "uppercase letter"
 
--- | Parses a lower case character (a character between \'a\' and \'z\').
+-- | Parses a lower case unicode character
 -- Returns the parsed character.
 
 lower :: (Stream s m Char) => ParsecT s u m Char

--- a/Text/Parsec/Char.hs
+++ b/Text/Parsec/Char.hs
@@ -3,13 +3,13 @@
 -- Module      :  Text.Parsec.Char
 -- Copyright   :  (c) Daan Leijen 1999-2001, (c) Paolo Martini 2007
 -- License     :  BSD-style (see the LICENSE file)
--- 
+--
 -- Maintainer  :  derek.a.elkins@gmail.com
 -- Stability   :  provisional
 -- Portability :  portable
--- 
+--
 -- Commonly used character parsers.
--- 
+--
 -----------------------------------------------------------------------------
 
 {-# LANGUAGE FlexibleContexts #-}
@@ -24,7 +24,7 @@ import Control.Applicative ((*>))
 -- | @oneOf cs@ succeeds if the current character is in the supplied
 -- list of characters @cs@. Returns the parsed character. See also
 -- 'satisfy'.
--- 
+--
 -- >   vowel  = oneOf "aeiou"
 
 oneOf :: (Stream s m Char) => [Char] -> ParsecT s u m Char
@@ -45,18 +45,18 @@ spaces :: (Stream s m Char) => ParsecT s u m ()
 spaces              = skipMany space        <?> "white space"
 
 -- | Parses a white space character (any character which satisfies 'isSpace')
--- Returns the parsed character. 
+-- Returns the parsed character.
 
 space :: (Stream s m Char) => ParsecT s u m Char
 space               = satisfy isSpace       <?> "space"
 
--- | Parses a newline character (\'\\n\'). Returns a newline character. 
+-- | Parses a newline character (\'\\n\'). Returns a newline character.
 
 newline :: (Stream s m Char) => ParsecT s u m Char
 newline             = char '\n'             <?> "lf new-line"
 
 -- | Parses a carriage return character (\'\\r\') followed by a newline character (\'\\n\').
--- Returns a newline character. 
+-- Returns a newline character.
 
 crlf :: (Stream s m Char) => ParsecT s u m Char
 crlf                = char '\r' *> char '\n' <?> "crlf new-line"
@@ -70,48 +70,48 @@ crlf                = char '\r' *> char '\n' <?> "crlf new-line"
 endOfLine :: (Stream s m Char) => ParsecT s u m Char
 endOfLine           = newline <|> crlf       <?> "new-line"
 
--- | Parses a tab character (\'\\t\'). Returns a tab character. 
+-- | Parses a tab character (\'\\t\'). Returns a tab character.
 
 tab :: (Stream s m Char) => ParsecT s u m Char
 tab                 = char '\t'             <?> "tab"
 
 -- | Parses an upper case letter (a character between \'A\' and \'Z\').
--- Returns the parsed character. 
+-- Returns the parsed character.
 
 upper :: (Stream s m Char) => ParsecT s u m Char
 upper               = satisfy isUpper       <?> "uppercase letter"
 
 -- | Parses a lower case character (a character between \'a\' and \'z\').
--- Returns the parsed character. 
+-- Returns the parsed character.
 
 lower :: (Stream s m Char) => ParsecT s u m Char
 lower               = satisfy isLower       <?> "lowercase letter"
 
 -- | Parses a letter or digit (a character between \'0\' and \'9\').
--- Returns the parsed character. 
+-- Returns the parsed character.
 
 alphaNum :: (Stream s m Char => ParsecT s u m Char)
 alphaNum            = satisfy isAlphaNum    <?> "letter or digit"
 
 -- | Parses a letter (an upper case or lower case character). Returns the
--- parsed character. 
+-- parsed character.
 
 letter :: (Stream s m Char) => ParsecT s u m Char
 letter              = satisfy isAlpha       <?> "letter"
 
--- | Parses a digit. Returns the parsed character. 
+-- | Parses a digit. Returns the parsed character.
 
 digit :: (Stream s m Char) => ParsecT s u m Char
 digit               = satisfy isDigit       <?> "digit"
 
 -- | Parses a hexadecimal digit (a digit or a letter between \'a\' and
--- \'f\' or \'A\' and \'F\'). Returns the parsed character. 
+-- \'f\' or \'A\' and \'F\'). Returns the parsed character.
 
 hexDigit :: (Stream s m Char) => ParsecT s u m Char
 hexDigit            = satisfy isHexDigit    <?> "hexadecimal digit"
 
 -- | Parses an octal digit (a character between \'0\' and \'7\'). Returns
--- the parsed character. 
+-- the parsed character.
 
 octDigit :: (Stream s m Char) => ParsecT s u m Char
 octDigit            = satisfy isOctDigit    <?> "octal digit"
@@ -124,7 +124,7 @@ octDigit            = satisfy isOctDigit    <?> "octal digit"
 char :: (Stream s m Char) => Char -> ParsecT s u m Char
 char c              = satisfy (==c)  <?> show [c]
 
--- | This parser succeeds for any character. Returns the parsed character. 
+-- | This parser succeeds for any character. Returns the parsed character.
 
 anyChar :: (Stream s m Char) => ParsecT s u m Char
 anyChar             = satisfy (const True)
@@ -144,7 +144,7 @@ satisfy f           = tokenPrim (\c -> show [c])
 -- | @string s@ parses a sequence of characters given by @s@. Returns
 -- the parsed string (i.e. @s@).
 --
--- >  divOrMod    =   string "div" 
+-- >  divOrMod    =   string "div"
 -- >              <|> string "mod"
 
 string :: (Stream s m Char) => String -> ParsecT s u m String

--- a/Text/Parsec/Char.hs
+++ b/Text/Parsec/Char.hs
@@ -87,13 +87,13 @@ upper               = satisfy isUpper       <?> "uppercase letter"
 lower :: (Stream s m Char) => ParsecT s u m Char
 lower               = satisfy isLower       <?> "lowercase letter"
 
--- | Parses a letter or digit (a character between \'0\' and \'9\').
+-- | Parses an alphabetic unicode character or digit (a character between \'0\' and \'9\').
 -- Returns the parsed character.
 
 alphaNum :: (Stream s m Char => ParsecT s u m Char)
 alphaNum            = satisfy isAlphaNum    <?> "letter or digit"
 
--- | Parses a letter (an upper case or lower case character). Returns the
+-- | Parses an alphabetic unicode character (an upper case or lower case character). Returns the
 -- parsed character.
 
 letter :: (Stream s m Char) => ParsecT s u m Char


### PR DESCRIPTION
documentation is misleading, e.g.

```
> Parsec.parse (Parsec.lower) "(source)" "λ"
Right '\955'
```